### PR TITLE
[notebooks] tools for usability

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,8 @@
+The ```cqa/``` directory holds notebooks pertaining to concurrentqa and the ```hqa/``` directory holds notebooks pertaining to hotpotqa.  
+
+For concurrentqa, notebooks are provided for:
+1. Inspecting the ConcurrentQA data format (```cqa/inspect.ipynb```)
+2. Inspecting the ConcurrentQA data topical slices (```cqa/sices.ipynb```)
+
+For hotpotqa, notebooks are provided for:
+1. Generating the HotpotQA-PAIR proxy dataset (```hqa/hqa_generate_pair.ipynb```)

--- a/notebooks/cqa/inspect.ipynb
+++ b/notebooks/cqa/inspect.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "077ee563-2e29-4a28-b884-12197e9b39f2",
+   "metadata": {},
+   "source": [
+    "# Inspect ConcurrentQA Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "75b3e0fa-c0ef-4680-a7a6-2b7aef6965d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import ast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5117a205-a35f-4936-a647-4126cb436187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prefix = \"../../\" # FILL IN PATH TO REPO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8798c88-88b5-4bd4-8021-0a2793178c51",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd51f55f-2dbe-43c5-ba03-4dced869bd07",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Reader training data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b3142b6c-3f6d-4137-ab5b-d212274ff6fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'question': \"According to the spokesperson who claimed Enron's exposure to Pacific Gas & Electric would not affect their financial condition, how long was Lay's meeting with Cheney?\",\n",
+       " 'answer': '30-minute',\n",
+       " '_id': 'PAIRIDX:63096',\n",
+       " 'domain': [0, 0],\n",
+       " 'type': 'bridge',\n",
+       " 'sp': [{'title': 'e856_p1',\n",
+       "   'sents': ['The stock was down 94 cents at $29.96 in late trading.',\n",
+       "    \"Charlotte-based Duke, which produces 3,000 megawatts, or about 5 percent of the state's power, fell $2.20 to $40.20 after reaching $38.44, down 9.3 percent.\",\n",
+       "    'A megawatt is enough to light 1,000 typical United States homes.',\n",
+       "    \"Houston-based Dynegy, which controls 2,800 megawatts of power in a partnership with NRG Energy Inc. of Minneapolis, fell $3.11 to $47.81 after falling as much as 9.7 percent to $46. NRG Energy shares fell $1.50 to $29.90. Calpine Corp., a San Jose, California-based generator and power-plant developer, fell $5.04, or 9.9 percent, to $45.60. Houston-based Reliant fell $1.85 to $43.50. Tulsa, Oklahoma-based Williams Cos. fell $1.17 to $40.70. Enron Corp. of Houston, which sells power and natural gas in California, fell $1.56 to $54.14. Enron's exposure to Pacific Gas & Electric ``will not have any material effect on earnings or our financial condition,'' Enron spokesman Vance Meyer said.\"],\n",
+       "   'sp_sent_idx': [3]},\n",
+       "  {'title': 'e2934_p5',\n",
+       "   'sents': ['Aides say Cheney met with only half a dozen of the interest groups seeking input into the policy, including Enron Corp., the Houston energy conglomerate that is a large and longtime Bush contributor, and the Edison Electric Institute, an energy trade group.',\n",
+       "    \"Vance Meyer, a spokesman for Enron, said the firm's chairman, Kenneth Lay, and another executive had a 30-minute meeting with Cheney.\",\n",
+       "    'Edison assembled 15 or 20 chief executives to meet with Cheney.',\n",
+       "    'But Lundquist and Knudsen, representing Cheney, met with half of the 400 or so groups -- industry, environmental, regulatory and academic -- that requested access.',\n",
+       "    'Exactly which groups the Cheney advisers met with is being kept secret by the White House.',\n",
+       "    \"The task force's stealthy operation reflects Cheney's distaste for publicity.\",\n",
+       "    'Following news reports about the private nature of the energy deliberations, Democrats on the House Energy and Commerce Committee and Government Reform Committee requested information about the groups the task force met with.'],\n",
+       "   'sp_sent_idx': [1]}]}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/data/CQA_train_all.json\") as f:\n",
+    "    train = [ast.literal_eval(line) for line in f]\n",
+    "    \n",
+    "train[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "839b1ac7-fc1c-4197-a31a-a569f8d2122d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b4e4d0e-cd6c-4280-bc4e-c35b545a97b0",
+   "metadata": {},
+   "source": [
+    "### Retriever training data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1fb9e216-7737-4f29-853d-ba557867694e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_id': 'PAIRIDX:63096',\n",
+       " 'answers': ['30-minute'],\n",
+       " 'question': \"According to the spokesperson who claimed Enron's exposure to Pacific Gas & Electric would not affect their financial condition, how long was Lay's meeting with Cheney?\",\n",
+       " 'pos_paras': [{'title': 'e856_p1',\n",
+       "   'text': \"The stock was down 94 cents at $29.96 in late trading. Charlotte-based Duke, which produces 3,000 megawatts, or about 5 percent of the state's power, fell $2.20 to $40.20 after reaching $38.44, down 9.3 percent. A megawatt is enough to light 1,000 typical United States homes. Houston-based Dynegy, which controls 2,800 megawatts of power in a partnership with NRG Energy Inc. of Minneapolis, fell $3.11 to $47.81 after falling as much as 9.7 percent to $46. NRG Energy shares fell $1.50 to $29.90. Calpine Corp., a San Jose, California-based generator and power-plant developer, fell $5.04, or 9.9 percent, to $45.60. Houston-based Reliant fell $1.85 to $43.50. Tulsa, Oklahoma-based Williams Cos. fell $1.17 to $40.70. Enron Corp. of Houston, which sells power and natural gas in California, fell $1.56 to $54.14. Enron's exposure to Pacific Gas & Electric ``will not have any material effect on earnings or our financial condition,'' Enron spokesman Vance Meyer said.\"},\n",
+       "  {'title': 'e2934_p5',\n",
+       "   'text': \"Aides say Cheney met with only half a dozen of the interest groups seeking input into the policy, including Enron Corp., the Houston energy conglomerate that is a large and longtime Bush contributor, and the Edison Electric Institute, an energy trade group. Vance Meyer, a spokesman for Enron, said the firm's chairman, Kenneth Lay, and another executive had a 30-minute meeting with Cheney. Edison assembled 15 or 20 chief executives to meet with Cheney. But Lundquist and Knudsen, representing Cheney, met with half of the 400 or so groups -- industry, environmental, regulatory and academic -- that requested access. Exactly which groups the Cheney advisers met with is being kept secret by the White House. The task force's stealthy operation reflects Cheney's distaste for publicity. Following news reports about the private nature of the energy deliberations, Democrats on the House Energy and Commerce Committee and Government Reform Committee requested information about the groups the task force met with.\"}],\n",
+       " 'neg_paras': [{'title': 'Ialmenus',\n",
+       "   'text': 'In Greek mythology, Ialmenus was a son of Ares and Astyoche, and twin brother of Ascalaphus. Together with his brother, he sailed with the Argonauts, was among the suitors of Helen and led the Orchomenian contingent in the Trojan War.'},\n",
+       "  {'title': 'Odyssey (TV channel)',\n",
+       "   'text': 'Odyssey (also known as OTN1) is a Canadian Greek language Category A specialty channel and is owned by Odyssey Television Network. It features programming from ANT1 Satellite, a private network from Greece as well as local Canadian content produced by Odyssey and other independent companies.'},\n",
+       "  {'title': 'Universidad, San Juan, Puerto Rico',\n",
+       "   'text': 'Universidad is one of the 18 districts of San Juan, Puerto Rico. It originally belonged to the municipality of Río Piedras. When Río Piedras was annexed to San Juan in 1951, Universidad became one of its districts.'},\n",
+       "  {'title': 'Loon Lake (novel)',\n",
+       "   'text': 'Loon Lake is a 1980 novel by E. L. Doctorow published in 1980. The plot of the novel is mostly set on Loon Lake in the Adirondacks during the Depression. The novel is one of the more experimental works of Doctorow, incorporating a great variety of different techniques, many of which are used for preventing the reader from an easy understanding of the narration: traditional narratives, stream of consciousness, poetry, mixed up chronology.'},\n",
+       "  {'title': \"She Ain't Got...\",\n",
+       "   'text': '\"She Ain\\'t Got...\" is a song recorded by American singer LeToya Luckett released as the second single taken from her second studio album Lady Love (2009). The song was written by LeToya Luckett, Andre Merritt, Chris Brown, Cory Bold and produced by Bold. The song was released on June 1, 2009, through Capital Records.'},\n",
+       "  {'title': 'Vidyasagar Shishu Niketan',\n",
+       "   'text': 'Vidyasagar Shishu Niketan is run by the Society for the Betterment of Education which was formed by a group of educationists and administrators on 4 September 1974 with the active help and encouragement from Sri Dipak Ghosh I.A.S, the then District Magistrate of Midnapore to impart better education to the school going children of Midnapore Town and to establish institutions for this purpose. This group felt that children should be able to feel at home anywhere in India during their student life and also later in their working life. For this reason, they decided to set up a school where education would be imparted through the medium of English.'},\n",
+       "  {'title': 'Karen Ellemann',\n",
+       "   'text': 'Karen Ellemann (born Charlottenlund, 26 August 1969) is a Danish member of parliament for the party Venstre and current Minister for Equality and'},\n",
+       "  {'title': 'Mary Adamson Anderson Marshall',\n",
+       "   'text': 'Mary Anderson (Mary Adamson Anderson Marshall, 1837 – 1910) was a physician and one of the members of the Edinburgh Seven, the first women to study medicine at the University of Edinburgh.'},\n",
+       "  {'title': 'Anacomp',\n",
+       "   'text': 'Anacomp, Inc., is an American company that specializes in computer services and document management. It was founded in Indianapolis, Indiana in 1968 by three Purdue University professors, but is now headquartered in Chantilly, Virginia. The name Anacomp is a combination of the words ANAlyze and COMPute . Since its inception, Anacomp has made many acquisitions and spin-offs and has entered and exited different lines of business.'},\n",
+       "  {'title': 'High School English',\n",
+       "   'text': '\"High School English\" is the seventh episode of the fifteenth season of the animated sitcom \"Family Guy\", and the 276th episode overall. It aired on Fox in the United States on November 20, 2016, and is written by Ted Jessup and directed by Steve Robertson.'},\n",
+       "  {'title': 'Schoenoplectus heterochaetus',\n",
+       "   'text': 'Schoenoplectus heterochaetus is a species of flowering plant in the sedge family known by the common name slender bulrush. It is native to North America, where it can be found in scattered locations in Canada and the United States.'},\n",
+       "  {'title': 'Ann Mroz',\n",
+       "   'text': 'Ann Mroz is a British-Polish journalist, former editor of Times Higher Education and current editor and digital publishing director of the TES (Times Educational Supplement).'},\n",
+       "  {'title': 'Philip van Dijk',\n",
+       "   'text': 'Philip van Dijk (10 January 1683 – 2 February 1753) was an 18th-century painter from the Northern Netherlands'},\n",
+       "  {'title': 'Push–pull connector',\n",
+       "   'text': 'The Push–pull connector was invented by Swiss connectors manufacturer LEMO and is a type of cable interconnect that provides a strong locking mechanism that is only released by squeezing the connector body, preventing accidental disconnects. The connector is cylindrical, enabling a wide range of body styles and configurations such as low or high voltage multipin, coaxial, triaxial, fluid and gas.'},\n",
+       "  {'title': 'Alabaster (disambiguation)',\n",
+       "   'text': 'Alabaster is a name applied to certain minerals, mainly gypsum (a hydrous sulfate of calcium) and calcite (a carbonate of calcium).'},\n",
+       "  {'title': 'England national blind cricket team',\n",
+       "   'text': 'England National Blind Cricket Team represents England at Blind cricket.England blind cricket team went onto participate in the inaugural edition of the Blind Cricket World Cup in 1998.The England blind cricket team also mainly participates in T20 Internationals and One Dayers'},\n",
+       "  {'title': 'e4740_p3',\n",
+       "   'text': \"Mr. Brooks and Mr. Eggers will also serve on Iris Labs' board, along with Jennifer Gill Roberts of Sevin Rosen. Mr. Brooks, Ms. Roberts, and George Chase of Hook Partners will sit on Metera's board. http: www.irislabs.com Infrastructure Provider Intira Holds $140 Million Round Two PLEASANTON, Calif. -- Intira, a provider of IT and network infrastructure for online business applications on an outsourced basis, said it raised over $140 million in its second round of funding. Investors in the round include Bain Capital, Chase Capital Partners, Lehman Brothers, Mayfield Fund, New Enterprise Associates, and Spectrum Equity Investors also funded the round. The company wil use the funding to further develop its outsourced infrastructure platform, create and improve service level agreements, and for customer initiatives. Intira has also been backed by Apollo Group, Cargil Associates, Goldman Sachs, Lowes, Och-Ziff Management, and Putnam Investments. http: www.intira.com Free Internet Firm Freei Networks Files For Bankruptcy FEDERAL WAY, Wash. -- After laying off a third of its staff and pulling its IPO last week, Freei Networks has filed for Chapter 11 bankruptcy protection.\"},\n",
+       "  {'title': 'Briarfield Academy',\n",
+       "   'text': 'Briarfield Academy is a non-sectarian, private school admitting pre-Kindergarten through twelfth grade students. It is located on Riddle Lane in Lake Providence in East Carroll Parish in northeastern Louisiana. The school has more than 250 students.'},\n",
+       "  {'title': 'Chaim Richman',\n",
+       "   'text': 'Chaim Richman is a rabbi in Israel, the International Director of the Temple Institute, which is dedicated to the rebuilding of the Holy Temple in Jerusalem, and a member of the current effort to revive the Sanhedrin.'}],\n",
+       " 'type': 'bridge',\n",
+       " 'bridge': 'e2934_p5'}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/data/Retriever_CQA_train_all_original.json\") as f:\n",
+    "    train = [ast.literal_eval(line) for line in f]\n",
+    "    \n",
+    "train[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a3a8c4c-08c4-4dd5-b954-7a92f194f444",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea621d25-b0a7-46c7-8752-22445383c87d",
+   "metadata": {},
+   "source": [
+    "#### Passage title to sentences map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "34cf8aaf-558f-4bac-9066-63616312c0a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/corpora/title2sent_map.json\") as f:\n",
+    "    title2sents = json.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a6096d9e-c961-4d43-a44a-ff69aa0d0333",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "One Night Stand (1984 film) ['One Night Stand is a 1984 film directed by John Duigan.']\n"
+     ]
+    }
+   ],
+   "source": [
+    "for ind, (k, v) in enumerate(title2sents.items()):\n",
+    "    print(k, v)\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd0f378-dd20-4a43-8684-df044cb60632",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d792ade7-9087-4c6c-8eef-06fc92e5705b",
+   "metadata": {},
+   "source": [
+    "### Background corpora"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaad22b7-c038-4c89-a58a-cbab4ba59e00",
+   "metadata": {},
+   "source": [
+    "##### For enron passages:\n",
+    "\n",
+    "'id': unique passage id  \n",
+    "'email_title': passage title  \n",
+    "'text': passage text  \n",
+    "'sents': passage text split into sentences  \n",
+    "'ner_tags_lst': list of NER tags annotated over the text  (using Spacy)  \n",
+    "'linked_entities_lst': list of entities linked to Wikidata from the text (using Spacy entity linker)  \n",
+    "'GLOBAL_ENTITIES':  final curated list of global entities in the passage\n",
+    "'LOCAL_ENTITIES':  final curated list of local entities in the passage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "85f93894-025b-4a19-ae95-26a7323d1e8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "e0_p0 dict_keys(['id', 'email_title', 'title', 'text', 'sents', 'ner_tags_lst', 'linked_entities_lst', 'GLOBAL_ENTITIES', 'LOCAL_ENTITIES'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/data/corpora/enron_only_corpus.json\") as f:\n",
+    "    corpus = json.load(f)\n",
+    "    \n",
+    "for ind, (k, v) in enumerate(corpus.items()):\n",
+    "    print(k, v.keys())\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b804df3c-2b4c-4288-8979-eae8efdd4935",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e93f8a2e-6ef0-4ee9-8d27-a6e0b8811842",
+   "metadata": {},
+   "source": [
+    "##### For Wiki passages:\n",
+    "'title': passage title   \n",
+    "'text': passage text  \n",
+    "'sents': passage text split into sentences   \n",
+    "'id': unique passage id  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0935f27b-89c7-41ec-8892-02708b41075a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/data/corpora/wiki_only_corpus.json\") as f:\n",
+    "    corpus = json.load(f)\n",
+    "    \n",
+    "for ind, (k, v) in enumerate(corpus.items()):\n",
+    "    print(k, v)\n",
+    "    break\n",
+    "    \n",
+    "v.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56946554-df79-4c7d-be43-e71579d7cac9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec516997-3c47-407f-abfa-438b62300ae2",
+   "metadata": {},
+   "source": [
+    "##### Combined enron and wiki passages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "12dd1024-30cc-4e6c-92a2-5480b883e5c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 {'title': 'One Night Stand (1984 film)', 'text': 'One Night Stand is a 1984 film directed by John Duigan.', 'sents': ['One Night Stand is a 1984 film directed by John Duigan.'], 'id': '0'}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['title', 'text', 'sents', 'id'])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/data/corpora/combined_corpus.json\") as f:\n",
+    "    corpus = json.load(f)\n",
+    "    \n",
+    "for ind, (k, v) in enumerate(corpus.items()):\n",
+    "    print(k, v)\n",
+    "    break\n",
+    "    \n",
+    "v.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac316408-5a7f-47d4-afa9-915c709b6880",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94837932-5886-44d9-b90b-bbba51e4d021",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/cqa/slices.ipynb
+++ b/notebooks/cqa/slices.ipynb
@@ -1,0 +1,737 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5103777",
+   "metadata": {},
+   "source": [
+    "# ConcurrentQA Slices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fe8321ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6403586f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "import sys\n",
+    "import ujson\n",
+    "import json\n",
+    "from tqdm import tqdm\n",
+    "import pandas as pd\n",
+    "import time\n",
+    "import ast\n",
+    "import re\n",
+    "import random\n",
+    "import statistics\n",
+    "from collections import Counter, defaultdict, OrderedDict\n",
+    "from typing import TYPE_CHECKING, Optional, Tuple, Callable, Dict, Any, List"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "08ed52cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prefix = \"../../\" # FILL IN PATH TO REPO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be000f4b-d96b-4e9b-a497-54f1314b79cd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0d58525",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5890bfce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(f\"{prefix}/datasets/concurrentqa/data/CQA_train_all.json\") as f:\n",
+    "    all_points = [ast.literal_eval(line) for line in f]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "5ae275fc-85d7-49fd-9bfb-3aaed5d454a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 15239/15239 [00:00<00:00, 344923.04it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_answers = []\n",
+    "all_questions = []\n",
+    "all_domains = []\n",
+    "questionddtype_counts = Counter()\n",
+    "all_points_dict = {}\n",
+    "\n",
+    "for d in tqdm(all_points):\n",
+    "    q_type =  d['type']\n",
+    "    answer = d['answer'] \n",
+    "    domain = d['domain']\n",
+    "    question = d['question']\n",
+    "    all_answers.append(answer)\n",
+    "    all_questions.append(question)\n",
+    "    all_points_dict[d['_id']] = d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4a77fe3-267c-4f3b-b810-65fdfe9cb1b5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ae9f1f4",
+   "metadata": {},
+   "source": [
+    "## Topical Slices of the Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c7ae712d-aafc-4f92-a14c-9eddac098882",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>question</th>\n",
+       "      <th>answer</th>\n",
+       "      <th>_id</th>\n",
+       "      <th>domain</th>\n",
+       "      <th>type</th>\n",
+       "      <th>sp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>PAIRIDX:63096</th>\n",
+       "      <td>According to the spokesperson who claimed Enro...</td>\n",
+       "      <td>30-minute</td>\n",
+       "      <td>PAIRIDX:63096</td>\n",
+       "      <td>[0, 0]</td>\n",
+       "      <td>bridge</td>\n",
+       "      <td>[{'title': 'e856_p1', 'sents': ['The stock was...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                        question     answer  \\\n",
+       "PAIRIDX:63096  According to the spokesperson who claimed Enro...  30-minute   \n",
+       "\n",
+       "                         _id  domain    type  \\\n",
+       "PAIRIDX:63096  PAIRIDX:63096  [0, 0]  bridge   \n",
+       "\n",
+       "                                                              sp  \n",
+       "PAIRIDX:63096  [{'title': 'e856_p1', 'sents': ['The stock was...  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "shortlisted_keys = [key for key in all_points[0].keys()]\n",
+    "df = pd.DataFrame.from_dict(all_points_dict, orient='index', columns=shortlisted_keys)\n",
+    "df.head(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6649b50d-42f6-40a7-9c8b-c6953fa3c8c7",
+   "metadata": {},
+   "source": [
+    "##### investment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b3bee033-fa77-43c7-b7a5-67166aa59146",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Investing, found 1227, 0.08051709429752608 questions in slice.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_investors = []\n",
+    "for i, (ind, value) in enumerate(df.iterrows()):\n",
+    "    if re.search(\".*investor.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\".*funded.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\".*funder.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\".*backer.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\".*backed.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\"^Which investor.*backed both.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\"^Who.*backs both.*\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\"^What.*backer also backed.*?\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\"^.*invested in both.*and.*?\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\"^.*invested in.*round.*and.*?\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "    elif re.search(\"^.*invested in both.*as well as.*?\", value['question']):\n",
+    "        slice_investors.append(ind)\n",
+    "\n",
+    "print(f\"Investing, found {len(slice_investors)}, {len(slice_investors)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c1ed444-3aa0-40ec-952d-e4919d34945f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12abe5e3-be53-4a94-8d3a-d31b9a677a8a",
+   "metadata": {},
+   "source": [
+    "##### legal discourse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "00d209e0-d9ec-48fe-a8df-e3e5eaa713b4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Legal, found 329, 0.021589343132751494 questions in slice.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_legal = []\n",
+    "for i, (ind, value) in enumerate(df.iterrows()):\n",
+    "    if re.search(\".*judge.*\", value['question'].lower()):\n",
+    "        slice_legal.append(ind)\n",
+    "    elif re.search(\".* sued.*\", value['question'].lower()):\n",
+    "        slice_legal.append(ind)\n",
+    "    elif re.search(\".*bill .*\", value['question']):\n",
+    "        slice_legal.append(ind)\n",
+    "    elif re.search(\".*lawsuit.*\", value['question']):\n",
+    "        slice_legal.append(ind)\n",
+    "print(f\"Legal, found {len(slice_legal)}, {len(slice_legal)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "334ff062-3117-4989-9497-259f98280edf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26caa7f5-ef22-495a-844e-ce0cb14fb72d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "##### newspapers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "4dfeaa4c-c8af-4616-9045-b7bd815e14ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "News, found 900, 0.05905899337226852 questions in slice.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_newspapers = []\n",
+    "for i, (ind, value) in enumerate(df.iterrows()):\n",
+    "    if re.search(\".*paper.*\", value['question']):\n",
+    "        slice_newspapers.append(ind)\n",
+    "    elif re.search(\".*reported.*\", value['question']):\n",
+    "        slice_newspapers.append(ind)\n",
+    "    elif re.search(\".*staff writer.*\", value['question']):\n",
+    "        slice_newspapers.append(ind)\n",
+    "    elif re.search(\".*article.*\", value['question']):\n",
+    "        slice_newspapers.append(ind)\n",
+    "    elif re.search(\".*wrote a piece.*\", value['question']):\n",
+    "        slice_newspapers.append(ind)\n",
+    "\n",
+    "print(f\"News, found {len(slice_newspapers)}, {len(slice_newspapers)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85db19ad-6591-42bc-afd8-4c2f140230b3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a6ac353-5b7a-440c-be93-8a0bc3bc852b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "##### geography"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "aa2c2b06-b0dd-42ee-9a2b-46e9fc12fe87",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geography, found 69, 0.004527856158540586 questions in slice.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_geography = []\n",
+    "for i, (ind, value) in enumerate(df.iterrows()):\n",
+    "    if re.search(\".*based in what state.*\", value['question']):\n",
+    "        slice_geography.append(ind)\n",
+    "    elif re.search(\".*based in what city.*\", value['question']):\n",
+    "        slice_geography.append(ind)\n",
+    "    elif re.search(\".*based in what country.*\", value['question']):\n",
+    "        slice_geography.append(ind)\n",
+    "    elif re.search(\".*located in what state.*\", value['question']):\n",
+    "        slice_geography.append(ind)\n",
+    "    elif re.search(\".*located in what city.*\", value['question']):\n",
+    "        slice_geography.append(ind)\n",
+    "\n",
+    "print(f\"Geography, found {len(slice_geography)}, {len(slice_geography)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "663fda58-6b74-4e21-8901-39d1a9a179f4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f3005c8-1876-4aaf-90ed-8b03a37178c9",
+   "metadata": {},
+   "source": [
+    "##### population"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "651019ef-a3fe-4112-8b48-514792f313b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geography, found 262, 0.017192729181704836 questions in slice.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_population = []\n",
+    "for i, (ind, value) in enumerate(df.iterrows()):\n",
+    "    if re.search(\".*population of.*\", value['question']):\n",
+    "        slice_population.append(ind)\n",
+    "\n",
+    "print(f\"Geography, found {len(slice_population)}, {len(slice_population)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54035ab1-1f33-4ac7-8870-cc9d1a5c021c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e2502ae-9e93-4fbf-a264-0bf8a3563212",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "##### birth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "39a25e23-3cd1-424c-b43a-d7b138a8ffae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "15239it [00:06, 2536.71it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Birth, found 351, 0.023033007415184725 questions in slice.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_birth = []\n",
+    "for i, (ind, value) in tqdm(enumerate(df.iterrows())):\n",
+    "    if re.search(\".*year of birth.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*date of birth.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*month of birth.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*was born in.*what year\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*was born in.*what month\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\"^When was.*born.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\"^Where was.*born.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*place of birth.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*was born in.*what city\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*was born in.*what place\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "    elif re.search(\".*was born where.*\", value['question']):\n",
+    "        slice_birth.append(ind)\n",
+    "\n",
+    "print(f\"Birth, found {len(slice_birth)}, {len(slice_birth)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30a4f19b-d97c-4a54-927f-0ef107828106",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3281394c-22ba-4722-affc-e4438809041f",
+   "metadata": {},
+   "source": [
+    "##### stock prices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "6656d6a8-3723-4266-a874-12b7ee867234",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "15239it [00:04, 3773.14it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stocks, found 42, 0.002756086357372531 questions in slice.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_stocks = []\n",
+    "for i, (ind, value) in tqdm(enumerate(df.iterrows())):\n",
+    "    if re.search(\".*stock price.*\", value['question']):\n",
+    "        slice_stocks.append(ind)\n",
+    "    elif re.search(\".*share price.*\", value['question']):\n",
+    "        slice_stocks.append(ind)\n",
+    "    elif re.search(\".*dollars per share.*\", value['question']):\n",
+    "        slice_stocks.append(ind)\n",
+    "    elif re.search(\".*cents.*share.*\", value['question']):\n",
+    "        slice_stocks.append(ind)\n",
+    "    elif re.search(\".*quarter.*earnings.*\", value['question']):\n",
+    "        slice_stocks.append(ind)\n",
+    "\n",
+    "print(f\"Stocks, found {len(slice_stocks)}, {len(slice_stocks)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2460a706-fd36-4fe7-86ee-2ab79c6a4a60",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "051e339c-a294-476f-8bcd-3e02e38a7b71",
+   "metadata": {},
+   "source": [
+    "##### email features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "2177ff38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "15239it [00:04, 3695.24it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emails Features, found 141, 0.009252575628322069 questions in slice.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_email_ftrs = []\n",
+    "for i, (ind, value) in tqdm(enumerate(df.iterrows())):\n",
+    "    if re.search(\".*sent an e-mail on.*\", value['question']):\n",
+    "        slice_email_ftrs.append(ind)\n",
+    "    elif re.search(\".*the recipient.*e-mail*\", value['question']):\n",
+    "        slice_email_ftrs.append(ind)\n",
+    "    elif re.search(\".*e-mail*\", value['question']):\n",
+    "        slice_email_ftrs.append(ind)\n",
+    "    elif re.search(\".*e-mail*\", value['question']):\n",
+    "        slice_email_ftrs.append(ind)\n",
+    "        \n",
+    "print(f\"Emails Features, found {len(slice_email_ftrs)}, {len(slice_email_ftrs)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6a6e8a3-6190-47b2-8d9a-3ad3ac05b43c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "685e535d-e864-40a0-9448-52076b49e342",
+   "metadata": {},
+   "source": [
+    "##### Company positions and titles of employees"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "076838b2-0036-41bd-94ca-81064a304371",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "15239it [00:05, 2918.85it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Positions, found 274, 0.017980182426668417 questions in slice.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "slice_position = []\n",
+    "for i, (ind, value) in tqdm(enumerate(df.iterrows())):\n",
+    "    if re.search(\".*is the president.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "    elif re.search(\".*is the vice president.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "    elif re.search(\".*chief.*officer.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "    elif re.search(\"Who is the.*of.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "    elif re.search(\".*holds.*position at.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "    elif re.search(\".*is the head of.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "    elif re.search(\".*board member.*\", value['question']):\n",
+    "        slice_position.append(ind)\n",
+    "\n",
+    "print(f\"Positions, found {len(slice_position)}, {len(slice_position)/len(df)} questions in slice.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed543331-26b7-4b77-a758-454b4f4bc407",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/hqa/hqa_generate_pair.ipynb
+++ b/notebooks/hqa/hqa_generate_pair.ipynb
@@ -1,0 +1,390 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "854c9a67-475c-4403-8d09-1d8e39ca7d90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d1de1a6a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "import ujson, os\n",
+    "import json\n",
+    "from tqdm import tqdm\n",
+    "import os.path\n",
+    "import pandas as pd\n",
+    "import time\n",
+    "from collections import Counter, defaultdict, OrderedDict\n",
+    "import random\n",
+    "import ast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "72d92475-7f02-40ef-8c6f-4799ea509c48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prefix = \"concurrentqa/\" # FILL IN PATH TO REPOSITORY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d0a8bcb-4d2c-4935-ad4d-b24669b49d3c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db0daf39",
+   "metadata": {},
+   "source": [
+    "# Load original data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1053be18",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded full set of documents in 110.8920521736145\n"
+     ]
+    }
+   ],
+   "source": [
+    "st = time.time()\n",
+    "passages_path = f'{prefix}/datasets/hotpotqa/hotpot_index/wiki_id2doc.json'\n",
+    "with open(passages_path) as f:\n",
+    "    wiki_id2doc = json.load(f)\n",
+    "    passages = []\n",
+    "    for k, v in wiki_id2doc.items():\n",
+    "        v['id'] = k\n",
+    "        passages.append(v)\n",
+    "        \n",
+    "print(f\"Loaded full set of documents in {time.time() - st}\")\n",
+    "st = time.time()\n",
+    "\n",
+    "st = time.time()\n",
+    "df = pd.DataFrame(passages)\n",
+    "print(f\"Loaded full set of documents in {time.time() - st}\")\n",
+    "st = time.time()\n",
+    "df.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7d2faf41",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 17394/5233329 [00:00<00:30, 173827.02it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['One Night Stand is a 1984 film directed by John Duigan.']\n",
+      "\n",
+      "['Welty McCullogh (October 10, 1847 – August 31, 1889) was a Republican member of the U.S', 'House of Representatives from Pennsylvania.']\n",
+      "\n",
+      "['The Neuropterida are a clade of holometabolous insects with over 5,700 described species, containing the orders Neuroptera (lacewings, antlions), Megaloptera (dobsonflies, alderflies), and Raphidioptera (snakeflies).']\n",
+      "\n",
+      "['Bafia (beukpak) people inhabit the Mbam region in the centre province of Cameroon', 'Their origins are said to share many similarities with those of the Bamun and Tikar people', 'A division during migratory movements caused the two sets of groups to settle in different areas', 'Later, the islamisation of most of the Bamun territory further separated them', 'A yearly festival held in Fumban (Bamun territory) is considered by many to symbolize the recognition of their common heritage.']\n",
+      "\n",
+      "['The Viti Levu giant pigeon (\"Natunaornis gigoura\") is an extinct flightless pigeon of Viti Levu, the largest island in Fiji', 'It was only slightly smaller than the dodo (\"Raphus cucullatus\") and Rodrigues solitaire (\"Pezophaps solitaria\").']\n",
+      "\n",
+      "['Glusburn is a village, electoral ward and civil parish situated in Craven in North Yorkshire, England', 'Historically part of the West Riding of Yorkshire, the village is situated on the edge of the Yorkshire Dales, sits on the A6068 Kildwick to Hapton road, and is conjoined to the village of Sutton-in-Craven at the south.']\n",
+      "\n",
+      "['Labor Notes is a non-profit organization and network for rank-and-file union members and grassroots labor activists', 'Though officially titled the Labor Education and Research Project, the project is best known by the title of its monthly magazine', 'The magazine reports news and analysis about labor activity or problems facing the labor movement', 'In its pages it advocates for a revitalization of the labor movement through Social Movement Unionism and union democracy', 'Labor Notes is based out of Detroit, Michigan with an East Coast office located in Brooklyn, New York.']\n",
+      "\n",
+      "['Zombie is a studio album by Nigerian Afrobeat musician Fela Kuti', 'It was released in Nigeria by Coconut Records in 1976, and in the United Kingdom by Creole Records in 1977.']\n",
+      "\n",
+      "['\"The Nutcracker and the Mouse King\" (German: \"Nussknacker und Mausekönig\" ) is a story written in 1816 by German author E', 'T', 'A', \"Hoffmann, in which young Marie Stahlbaum's favorite Christmas toy, the Nutcracker, comes alive and, after defeating the evil Mouse King in battle, whisks her away to a magical kingdom populated by dolls\", 'In 1892, the Russian composer Pyotr Ilyich Tchaikovsky and choreographers Marius Petipa and Lev Ivanov turned Alexandre Dumas père\\'s adaptation of the story into the ballet \"The Nutcracker\", which became one of Tchaikovsky\\'s most famous compositions, and perhaps the most popular ballet in the world.']\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 5233329/5233329 [01:44<00:00, 49845.21it/s] "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5233329\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "alldomaintitles = []\n",
+    "title2sent_map = {}\n",
+    "count = 0\n",
+    "for k, v in tqdm(wiki_id2doc.items()):\n",
+    "    title = v['title']\n",
+    "    sents = v['text']\n",
+    "    sents = sents.split(\". \")\n",
+    "    \n",
+    "    alldomaintitles.append(title)\n",
+    "    title2sent_map[title] = sents\n",
+    "        \n",
+    "print(len(title2sent_map))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f8c2a36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(f'{prefix}/datasets/hotpotqa/hotpot/hotpot_qas_val.json') as f:\n",
+    "    qa_entries = []\n",
+    "    for line in f:\n",
+    "        entry = ast.literal_eval(line)\n",
+    "        qa_entries.append(entry)\n",
+    "print(f\"QAs set has {len(qa_entries)} data points.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0aebe74f-bd2e-46c3-b188-3c3b5dcb6e43",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4bff65c-09b6-419b-b6e3-0bd7822fd416",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "315cbd2c",
+   "metadata": {},
+   "source": [
+    "### The following generates new private/public data splits and prepares everything for running retrieval on HotpotQA Dev Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "8a9a033b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_item(item, domain=-1):\n",
+    "    item['domain'] = domain\n",
+    "    return item\n",
+    "\n",
+    "def get_domain_splits(private_prop, alldomaintitles):\n",
+    "    title2domain = {}\n",
+    "    domain1titles = []\n",
+    "    domain2titles = []\n",
+    "    random.seed(0)\n",
+    "    \n",
+    "    # splits by title randomly \n",
+    "    for title in tqdm(alldomaintitles):\n",
+    "        randnum = random.random()\n",
+    "        if randnum > private_prop:\n",
+    "            title2domain[title] = 0\n",
+    "            domain1titles.append(title)\n",
+    "        else:\n",
+    "            title2domain[title] = 1\n",
+    "            domain2titles.append(title)\n",
+    "            \n",
+    "    return title2domain, domain1titles, domain2titles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3c1e027b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "7405it [00:00, 156836.59it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are: 1837 local questions\n",
+      "There are: 1823 global questions\n",
+      "For 0 questions, could not find documents in corpus.\n",
+      "Fore 0 questions, contains private and public entities.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# we will do this for private splits of different sizes; private_prop 0.5 means equal 50-50 public-private splits\n",
+    "for private_prop in [0.5]:\n",
+    "    # path where you will save the generated data\n",
+    "    path = f\"{prefix}/datasets/hotpotqa_pair/hotpot_privateprop_{private_prop}/\"\n",
+    "    if not os.path.exists(path):\n",
+    "        os.makedirs(path)\n",
+    "\n",
+    "    title2domain, domain1titles, domain2titles = get_domain_splits(private_prop, alldomaintitles)\n",
+    "            \n",
+    "    # Save the passages\n",
+    "    print(f\"Num domain 1 titles: {len(domain1titles)}\")\n",
+    "    print(f\"Num domain 2 titles: {len(domain2titles)}\\n\")\n",
+    "    \n",
+    "    if not os.path.exists(path):\n",
+    "        print(f\"Making dir at: {path}\")\n",
+    "        os.makedirs(path)\n",
+    "    \n",
+    "    df['domain1'] = df['title'].apply(lambda x: title2domain[x]==0)\n",
+    "    df['domain2'] = df['title'].apply(lambda x: title2domain[x]==1)\n",
+    "    \n",
+    "    sub_df = df[df['domain1'] == True]\n",
+    "    dic = sub_df.to_dict('index')\n",
+    "    with open(f'{path}/domain0psgs.json', \"w\") as f:\n",
+    "        json.dump(dic, f)\n",
+    "    print(\"Saved domain 1 passages.\")\n",
+    "\n",
+    "    sub_df = df[df['domain2'] == True]\n",
+    "    dic = sub_df.to_dict('index')\n",
+    "    with open(f'{path}/domain1psgs.json', \"w\") as f:\n",
+    "        json.dump(dic, f)\n",
+    "    print(\"Saved domain 2 passages.\")\n",
+    "        \n",
+    "    # determine private and public entities of those appearing in the queries \n",
+    "    entity_df = pd.DataFrame(entitytitles.items(), columns=['entitytitle', 'domain'])\n",
+    "    entity_df['domain'] = entity_df['entitytitle'].apply(lambda x: title2domain[x]==0)\n",
+    "    entitytitle2domain_cache = {}\n",
+    "    for ind, row in entity_df.iterrows():\n",
+    "        entitytitle2domain_cache[row['entitytitle']] = row['domain']\n",
+    "    \n",
+    "    # Save the questions\n",
+    "    localquestions = []\n",
+    "    globalquestions = []\n",
+    "    not_in_corpus = 0\n",
+    "    for idx, item in tqdm(enumerate(qa_entries)):\n",
+    "        sps = item['sp']\n",
+    "        \n",
+    "        domains  = [entitytitle2domain_cache[sp['title']] for sp in sps]\n",
+    "        domain1_exists = any(d == True  for d in domains)\n",
+    "        domain2_exists = any(d == False for d in domains)\n",
+    "        neither_exists = not domain1_exists and not domain2_exists\n",
+    "        \n",
+    "        if domain1_exists and not domain2_exists:\n",
+    "            localquestions.append(process_item(item, domain=domains))\n",
+    "        if not domain1_exists and domain2_exists:\n",
+    "            globalquestions.append(process_item(item, domain=domains))\n",
+    "        if neither_exists:\n",
+    "            not_in_corpus += 1\n",
+    "\n",
+    "    print(f\"There are: {len(localquestions)} local questions\")\n",
+    "    print(f\"There are: {len(globalquestions)} global questions\")\n",
+    "    print(f\"For {not_in_corpus} questions, could not find documents in corpus.\")\n",
+    "    \n",
+    "    if not os.path.exists(f'{path}/domain_0/'):\n",
+    "        os.makedirs(f'{path}/domain_0/')\n",
+    "    if not os.path.exists(f'{path}/domain_1/'):\n",
+    "        os.makedirs(f'{path}/domain_1/')\n",
+    "    \n",
+    "    with open(f'{path}/domain_0/hotpot_qas_val_domain0.json', 'w') as f:\n",
+    "        for question in localquestions:\n",
+    "            json.dump(question, f)\n",
+    "            f.write(\"\\n\")\n",
+    "    with open(f'{path}/domain_1/hotpot_qas_val_domain1.json', 'w') as f:\n",
+    "        for question in globalquestions:\n",
+    "            json.dump(question, f)\n",
+    "            f.write(\"\\n\")\n",
+    "            \n",
+    "    allquestions = localquestions.copy()\n",
+    "    allquestions.extend(globalquestions.copy())\n",
+    "    with open(f'{path}/hotpot_qas_val_all.json', 'w') as f:\n",
+    "        for question in allquestions:\n",
+    "            json.dump(question, f)\n",
+    "            f.write(\"\\n\")\n",
+    "            \n",
+    "    print(f\"Saved data for private proportion {private_prop}.\")\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc2ac87b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This commit includes notebooks to help explore the ConcurrentQA and HotpotQA-PAIR benchmarks.

For ConcurrentQA, notebooks help view the data format and topic slices. For HotpotQA, the notebook helps generate the HotpotQA-PAIR proxy dataset.